### PR TITLE
update solana v1.16.26

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_LANG = 'en'
-export const DEFAULT_SOLANA_VERSION = '1.16.25'
+export const DEFAULT_SOLANA_VERSION = '1.16.26'
 export const DEFAULT_NODE_VERSION = '20.10.0'
 export const DEFAULT_DELINQUENT_STAKE = 5
 export const DEFAULT_COMMISSION = 10


### PR DESCRIPTION
Quote comment from Discord:
The v1.16.26 release is now recommended for use on Testnet. Please upgrade when there's less than 5% delinquent stake.

Discord (Solana Tech):
https://discord.com/channels/428295358100013066/594138785558691840/1193772736871411893

GitHub:
https://github.com/solana-labs/solana/releases/tag/v1.16.26