### PR TITLE
update solana v1.17.16

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_LANG = 'en'
-export const DEFAULT_SOLANA_VERSION = '1.16.27'
+export const DEFAULT_SOLANA_VERSION = '1.17.16'
 export const DEFAULT_NODE_VERSION = '20.10.0'
 export const DEFAULT_DELINQUENT_STAKE = 5
 export const DEFAULT_COMMISSION = 10


### PR DESCRIPTION
## Current progress
```
1. Upgrade testnet to v1.17.15
2. Downgrade testnet to v1.16.26
3. Upgrade testnet to v1.17 <- We're here
```
Source: https://discord.com/channels/428295358100013066/594138785558691840/1194407242162774066

## Update announcements
```
This is the final version change for the v1.17 upgrade testing. Thank you to all the testnet operators who have upgraded and downgraded multiple times over the last few weeks.

The v1.17.16 release is now recommended for use on Testnet. Please upgrade when there's less than 5% delinquent stake.

https://github.com/solana-labs/solana/releases/tag/v1.17.16
```

testnet-announcements: https://discord.com/channels/428295358100013066/594138785558691840/1196244791961321655