### PR TITLE
update solana v1.17.16 (stay this ver)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -38,7 +38,7 @@ export type PartialConfigType = Partial<CONFIG_TYPE>
 export const CONFIG: CONFIG_TYPE = {
   LANG: LANGS.EN,
   USERNAME: 'solv',
-  SOLANA_VERSION: '1.18.0',
+  SOLANA_VERSION: '1.17.16',
   NODE_VERSION: '20.10.0',
   DELINQUENT_STAKE: 5,
   COMMISSION: 10,


### PR DESCRIPTION
Solana testnet-announcements say "Stay on v1.17".

```
There's an incompatibility in v1.18.0. Stay on v1.17 for now. The issue is being investigated.
```

Source: https://discord.com/channels/428295358100013066/594138785558691840/1201569252977688587