### PR TITLE
feat(fix): change 2.0 version check to versions starting with 2.

### DIFF
--- a/packages/solv/src/config/getSolanaCLI.ts
+++ b/packages/solv/src/config/getSolanaCLI.ts
@@ -8,8 +8,8 @@ export type SolanaCLI = typeof SOLANA_CLI | typeof AGAVE_CLI
 const getSolanaCLI = (): SolanaCLI => {
   try {
     const solanaVersion = getSolanaVersion()
-    const hasVersion20 = solanaVersion.includes('2.0')
-    if (hasVersion20) {
+    const hasVersion2 = solanaVersion.startsWith('2.')
+    if (hasVersion2) {
       return AGAVE_CLI
     }
     return SOLANA_CLI


### PR DESCRIPTION
When checking for `agave-validator` VS `solana-validator` we are comparing the version string against a string of `2.0`.

Instead, we should check if the version starts with `2.` to accommodate 2.0.x 2.1.x etc.

This is a band-aid until Solana version 20.x is released.